### PR TITLE
Split install steps on copy and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ $(SRCDIR):
 $(SRCCLEAN) $(DEPCLEAN): %.clean:
 	$(MAKE) -C $* clean
 
-install:
+copy-riscv-tests: $(BUILDDIR)
+	cp -a $(DEPDIR)/riscv-tests/isa/*.bin $(DEPDIR)/riscv-tests/isa/*.dump $(BUILDDIR)
+
+install: copy-riscv-tests
 	mkdir -p $(INSTALLDIR)
-	cp -a $(DEPDIR)/riscv-tests/isa/*.bin $(DEPDIR)/riscv-tests/isa/*.dump $(INSTALLDIR)
 	cp -a $(BUILDDIR)/*.bin $(BUILDDIR)/*.dump $(INSTALLDIR)
 
 toolchain-env:


### PR DESCRIPTION
Split the step so the binaries can be used without installation